### PR TITLE
Delete trailing whitespace in the Markdown template

### DIFF
--- a/main.go
+++ b/main.go
@@ -143,5 +143,5 @@ Problems
 {{ .Detail }}
 {{- end }}
 
-{{- end}}{{end}} 
+{{- end}}{{end}}
 `


### PR DESCRIPTION
I am hoping this patch fixes this problem:

```
Terraform Readme.........................................................Failed
hookid: terraform_readme

Files were modified by this hook.

Terraform fmt............................................................Passed
Terraform validate without variables.....................................Passed
Check Yaml...........................................(no files to check)Skipped
Check JSON...........................................(no files to check)Skipped
Check for broken symlinks............................(no files to check)Skipped
Forbid new submodules....................................................Passed
Mixed line ending........................................................Passed
Don't commit to branch...................................................Passed
Pretty format JSON...................................(no files to check)Skipped
Fix End of Files.........................................................Passed
Trim Trailing Whitespace.................................................Failed
hookid: trailing-whitespace

```