### PR TITLE
Fix empty strings and float outputs (OPS-3993)

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,8 +50,24 @@ func showModuleMarkdown(module *tfconfig.Module) {
 	tmpl := template.New("md")
 	tmpl.Funcs(template.FuncMap{
 		"tt": func(i interface{}) string {
-			s := fmt.Sprintf("%v", i)
+			var s string
+			switch i.(type) {
+			case float64, float32:
+				s = fmt.Sprintf("%.0f", i)
+			case nil:
+				return "``"
+			default:
+				s = fmt.Sprintf("%v", i)
+			}
 			return "`" + s + "`"
+		},
+		"req": func(i interface{}) string {
+			switch i.(type) {
+			case nil:
+				return "yes"
+			default:
+				return "no"
+			}
 		},
 		"commas": func(s []string) string {
 			return strings.Join(s, ", ")
@@ -94,7 +110,7 @@ const markdownTemplate = `
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 {{- range .Variables }}{{if skip .Pos }}
-| {{ tt .Name }} | {{- if .Description}}{{ .Description }}{{ end }} | {{- if .Type}}{{ .Type }}{{ end }} | {{ tt .Default }} | {{if tt .Default}}no{{else}}yes{{end}} |{{end}}{{end}}
+| {{ tt .Name }} | {{- if .Description}}{{ .Description }}{{ end }} | {{- if .Type}}{{ .Type }}{{ end }} | {{ tt .Default }} | {{req .Default }} |{{end}}{{end}}
 
 {{- if .Outputs}}
 

--- a/main.go
+++ b/main.go
@@ -17,7 +17,10 @@ func main() {
 	flag.Parse()
 
 	var dir string
-	if flag.NArg() > 0 {
+	if flag.NArg() > 0 && flag.Arg(0) == "--version" {
+		fmt.Println("0.2.0")
+		return
+	} else if flag.NArg() > 0 {
 		dir = flag.Arg(0)
 	} else {
 		dir = "."


### PR DESCRIPTION
Fixes:
 * Empty string are now defaulted to "``" and requird is set to yes
 * Output of floats in non-scientific notation
* Add `--version` option